### PR TITLE
Rychlá oprava pro #1

### DIFF
--- a/game/team.go
+++ b/game/team.go
@@ -161,7 +161,8 @@ func (t *Team) LogCipherArrival(cipher CipherConfig) error {
 	for _, prevID := range cipher.LogSolved {
 		prevCipher := t.gameConfig.ciphersMap[prevID]
 		prevCipherStatus := t.cipherStatus[prevID]
-		if prevCipherStatus.Solved == nil && prevCipherStatus.Skip == nil {
+	    _, found := t.cipherStatus[prevID]
+		if prevCipherStatus.Solved == nil && prevCipherStatus.Skip == nil && found {
 			if err := t.LogCipherSolved(prevCipher); err != nil {
 				return err
 			}


### PR DESCRIPTION
Všechny nenavštívené šifry se přeskakují, tedy jak pro orga, tak i pro účastníka se to chová stejně (možná i správně?).